### PR TITLE
fix: inkscape png conversion

### DIFF
--- a/pacgraph
+++ b/pacgraph
@@ -1132,7 +1132,7 @@ def main():
     if options.svg_only:
         return
     print('Rendering PNG')
-    png_conversion = ['inkscape -D -e %(fn)s.png %(fn)s.svg',
+    png_conversion = ['inkscape -D -o %(fn)s.png %(fn)s.svg',
                       'svg2png %(fn)s.svg %(fn)s.png',
                       'convert %(fn)s.svg %(fn)s.png']
     for cmd_line in png_conversion:


### PR DESCRIPTION
I noticed a while ago that pacgraph did not create a png file for me anymore.
Apparently Inkscape 1.3 changed the CLI commands for conversion, because there is no `-e` flag anymore.

This small change fixes that.