### PR TITLE
Fix pacgraph-tk regression for Python 3.12

### DIFF
--- a/pacgraph-tk
+++ b/pacgraph-tk
@@ -8,9 +8,21 @@ from multiprocessing import Process
 import sys, threading, queue, time
 
 if not dev:
-    import imp
-    imp.load_source('pacgraph', '/usr/bin/pacgraph')
-import pacgraph
+    module_name = 'pacgraph'
+    module_path = '/usr/bin/pacgraph'
+    if sys.version_info[1] >= 12:
+        import importlib.util
+        import importlib.machinery
+        loader = importlib.machinery.SourceFileLoader(module_name, module_path)
+        spec = importlib.util.spec_from_loader(module_name, loader)
+        if spec is None:
+            raise ImportError(f'Failed to load pacgraph module at {module_path}')
+        pacgraph = importlib.util.module_from_spec(spec)
+        loader.exec_module(pacgraph)
+    else:
+        import imp
+        imp.load_source(module_name, module_path)
+        import pacgraph
 
 colors = {'sel'  : '#000',
           'uns'  : '#888',

--- a/pacgraph-tk
+++ b/pacgraph-tk
@@ -10,7 +10,7 @@ import sys, threading, queue, time
 if not dev:
     module_name = 'pacgraph'
     module_path = '/usr/bin/pacgraph'
-    if sys.version_info[1] >= 12:
+    if sys.version_info[0] >= 3 and sys.version_info[1] >= 12:
         import importlib.util
         import importlib.machinery
         loader = importlib.machinery.SourceFileLoader(module_name, module_path)


### PR DESCRIPTION
Fixes issue #12.

# Backstory
CPython's `imp` module was considered deprecated since 3.4, and was completely removed at 3.12; `importlib` should be used instead. As of right now, Python 3.12 is the default Arch package, so pacgraph-tk is de facto broken out of the box.

# Relevant links
* [Python version in Arch](https://archlinux.org/packages/core/x86_64/python/) *(3.12.3 now)*
* [imp docs](https://docs.python.org/3.11/library/imp.html) -- note the deprecation notice.

# Changes
Added a conditional fork to import necessary package using `importlib` rather than `imp` for Python versions >= 3.12. Code was written in a way to as not to introduce syntax that would not be understood by earlier Python versions (e.g. installed manually or from AUR). 

# Testing
Manually tested on ArchLinux with default Python installation.

# References
- Answer by Levan Lovidze at [StackOverflow](https://stackoverflow.com/questions/76694726/replacing-imp-load-source-in-python-3-12#answer-77401571)
* [importlib docs](https://docs.python.org/3/library/importlib.html)
